### PR TITLE
Add support for WSL

### DIFF
--- a/src/cli/for.rs
+++ b/src/cli/for.rs
@@ -1,8 +1,9 @@
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 
-use anyhow::{ensure, Result};
+use anyhow::{bail, ensure, Result};
 use clap::Parser;
 
+use crate::config::Os;
 use crate::ctxt::Ctxt;
 use crate::model::Repo;
 use crate::process::Command;
@@ -12,6 +13,13 @@ pub(crate) struct Opts {
     /// Command to run.
     #[arg(value_name = "command")]
     command: OsString,
+    /// If the specified operating system is different for the repo, execute the
+    /// command using a compatibility layer which is appropriate for a supported
+    /// operating system.
+    ///
+    /// * On Windows, if a project is Linux-specific WSL will be used.
+    #[arg(long)]
+    run_on_os: bool,
     /// Arguments to pass to the command to run.
     #[arg(
         trailing_var_arg = true,
@@ -26,22 +34,56 @@ pub(crate) fn entry(cx: &mut Ctxt<'_>, opts: &Opts) -> Result<()> {
         cx,
         "run commands",
         format_args!("for: {opts:?}"),
-        |cx, repo| { r#for(cx, repo, &opts.command, &opts.args) }
+        |cx, repo| { r#for(cx, repo, opts) }
     );
 
     Ok(())
 }
 
 #[tracing::instrument(name = "for", skip_all)]
-fn r#for(cx: &Ctxt<'_>, repo: &Repo, command: &OsStr, args: &[OsString]) -> Result<()> {
+fn r#for(cx: &Ctxt<'_>, repo: &Repo, opts: &Opts) -> Result<()> {
     let path = cx.to_path(repo.path());
 
-    let mut command = Command::new(command);
-    command.args(args);
+    let mut command = Command::new(&opts.command);
+    command.args(&opts.args);
     command.current_dir(&path);
 
-    println!("{}:", path.display());
-    let status = command.status()?;
+    let mut runner = command;
+    let mut runner_name = None;
+
+    if opts.run_on_os {
+        let os = cx.config.os(repo);
+
+        'ok: {
+            if os.is_empty() || os.contains(&cx.os) {
+                break 'ok;
+            }
+
+            if cx.os == Os::Windows && os.contains(&Os::Linux) {
+                if let Some(wsl) = cx.system.wsl.first() {
+                    let mut command = wsl.shell(&path);
+                    command.arg(&opts.command);
+                    command.args(&opts.args);
+                    runner = command;
+                    runner_name = Some("WSL");
+                    break 'ok;
+                }
+            }
+
+            bail!(
+                "No supported runner for {os:?} on current system {:?}",
+                cx.os
+            );
+        }
+    }
+
+    if let Some(runner_name) = runner_name {
+        println!("{} ({runner_name}):", path.display());
+    } else {
+        println!("{}:", path.display());
+    }
+
+    let status = runner.status()?;
     ensure!(status.success(), status);
     Ok(())
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -74,7 +74,7 @@ async fn status(
 ) -> Result<bool> {
     let sha;
 
-    let sha = match &cx.git {
+    let sha = match cx.system.git.first() {
         Some(git) => {
             sha = git
                 .rev_parse(cx.to_path(repo.path()), "HEAD")

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,11 +310,12 @@ impl Replacement {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum Os {
     Windows,
     Linux,
     Mac,
+    Other(String),
 }
 
 #[derive(Default, Debug)]
@@ -614,8 +615,8 @@ impl Config<'_> {
     }
 
     /// Get supported operating systems.
-    pub(crate) fn os(&self, repo: &Repo) -> HashSet<Os> {
-        self.repos(repo).flat_map(|r| &r.os).copied().collect()
+    pub(crate) fn os(&self, repo: &Repo) -> HashSet<&Os> {
+        self.repos(repo).flat_map(|r| &r.os).collect()
     }
 
     /// Get the current license template.

--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -6,9 +6,10 @@ use std::process::{ExitCode, Stdio};
 use anyhow::{anyhow, Context, Result};
 use relative_path::RelativePath;
 
+use super::system::System;
 use crate::cargo::{self, Package, RustVersion};
 use crate::changes::{Change, Warning};
-use crate::config::Config;
+use crate::config::{Config, Os};
 use crate::env::Env;
 use crate::git::Git;
 use crate::model::{RenderRustVersions, Repo, RepoParams, RepoRef, State};
@@ -64,11 +65,12 @@ impl Paths<'_> {
 }
 
 pub(crate) struct Ctxt<'a> {
+    pub(crate) system: &'a System,
+    pub(crate) os: Os,
     pub(crate) paths: Paths<'a>,
     pub(crate) config: &'a Config<'a>,
     pub(crate) repos: &'a [Repo],
     pub(crate) rustc_version: Option<RustVersion>,
-    pub(crate) git: Option<Git>,
     pub(crate) warnings: RefCell<Vec<Warning>>,
     pub(crate) changes: RefCell<Vec<Change>>,
     pub(crate) sets: &'a mut RepoSets,
@@ -148,7 +150,7 @@ impl<'a> Ctxt<'a> {
 
     /// Require a working git command.
     pub(crate) fn require_git(&self) -> Result<&Git> {
-        self.git.as_ref().context("no working git command")
+        self.system.git.first().context("no working git command")
     }
 
     /// Push a change.

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,0 +1,66 @@
+use std::env;
+use std::env::consts::EXE_EXTENSION;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
+
+use anyhow::Result;
+
+use super::git;
+use super::wsl;
+
+/// Detect system commands.
+#[derive(Default)]
+pub(crate) struct System {
+    pub(crate) git: Vec<git::Git>,
+    pub(crate) wsl: Vec<wsl::Wsl>,
+}
+
+/// Detect everything useful we can find in the environment.
+pub(crate) fn detect() -> Result<System> {
+    let mut system = System::default();
+
+    if let Some(path) = env::var_os("GIT_PATH") {
+        let path = PathBuf::from(path);
+
+        if let Some(status) = git::version(path.as_os_str())? {
+            if status.success() {
+                system.git.push(git::Git::new(path));
+            }
+        }
+    }
+
+    let add_git =
+        |system: &mut System, path: &Path| system.git.push(git::Git::new(path.to_owned()));
+    let add_wsl =
+        |system: &mut System, path: &Path| system.wsl.push(wsl::Wsl::new(path.to_owned()));
+
+    let tests: &[(
+        &str,
+        fn(&OsStr) -> Result<Option<ExitStatus>>,
+        fn(&mut System, &Path),
+    )] = &[
+        ("git", git::version, add_git),
+        ("wsl", wsl::version, add_wsl),
+    ];
+
+    if let Some(path) = env::var_os("PATH") {
+        // Look for the command in the PATH.
+        for mut path in env::split_paths(&path) {
+            for &(name, test, add_to) in tests {
+                path.push(name);
+                path.set_extension(EXE_EXTENSION);
+
+                if let Some(status) = test(path.as_os_str())? {
+                    if status.success() {
+                        add_to(&mut system, &path);
+                    }
+                }
+
+                path.pop();
+            }
+        }
+    }
+
+    Ok(system)
+}

--- a/src/wsl.rs
+++ b/src/wsl.rs
@@ -1,0 +1,44 @@
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
+
+use anyhow::{Context, Result};
+
+use crate::process::Command;
+
+#[derive(Debug)]
+pub(crate) struct Wsl {
+    command: PathBuf,
+}
+
+impl Wsl {
+    #[inline]
+    pub(crate) fn new(command: PathBuf) -> Self {
+        Self { command }
+    }
+
+    /// Set up a WSL shell command.
+    pub(crate) fn shell<D>(&self, dir: D) -> Command
+    where
+        D: AsRef<Path>,
+    {
+        let mut command = Command::new(&self.command);
+        command.args(["--shell-type", "login"]);
+        command.current_dir(dir);
+        command
+    }
+}
+
+pub(crate) fn version(path: &OsStr) -> Result<Option<ExitStatus>> {
+    match std::process::Command::new(path)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+    {
+        Ok(status) => Ok(Some(status)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).context("docker --version"),
+    }
+}


### PR DESCRIPTION
This adds support for the `--run-on-os` flag with the `for` subcommand, which will look at the `os` configuration of a project and try to run the command under that OS using emulation.

The first supported emulation is WSL on Windows, which is what's provided here.

If a command is run under emulation, the emulation method is shown within parenthesis:

```shell
$ kick for --run-on-os cargo --version
repos/tokio-dbus (WSL):
cargo 1.78.0 (54d8815d0 2024-03-26)
repos/winctx:
cargo 1.78.0 (54d8815d0 2024-03-26)
repos/xmlparser:
cargo 1.78.0 (54d8815d0 2024-03-26)
repos/unlock:
cargo 1.78.0 (54d8815d0 2024-03-26)
```