### PR TITLE
Support passing in environment variables

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -310,7 +310,7 @@ impl Replacement {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum Os {
     Windows,
     Linux,
@@ -323,7 +323,7 @@ pub(crate) struct RepoConfig {
     /// Override crate to use.
     pub(crate) name: Option<String>,
     /// Supported operating system.
-    pub(crate) os: HashSet<Os>,
+    pub(crate) os: BTreeSet<Os>,
     /// Name of the repo branch.
     pub(crate) branch: Option<String>,
     /// Workflows to incorporate.
@@ -615,7 +615,7 @@ impl Config<'_> {
     }
 
     /// Get supported operating systems.
-    pub(crate) fn os(&self, repo: &Repo) -> HashSet<&Os> {
+    pub(crate) fn os(&self, repo: &Repo) -> BTreeSet<&Os> {
         self.repos(repo).flat_map(|r| &r.os).collect()
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -14,6 +14,7 @@ pub(crate) struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
+    env: Vec<(OsString, OsString)>,
 }
 
 impl Command {
@@ -28,6 +29,7 @@ impl Command {
             stdin: None,
             stdout: None,
             stderr: None,
+            env: Vec::new(),
         }
     }
 
@@ -50,6 +52,17 @@ impl Command {
             self.args.push(arg.as_ref().to_owned());
         }
 
+        self
+    }
+
+    /// Add an environment variable to the command.
+    pub(crate) fn env<K, V>(&mut self, key: K, value: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.env
+            .push((key.as_ref().to_owned(), value.as_ref().to_owned()));
         self
     }
 
@@ -130,6 +143,10 @@ impl Command {
 
         if let Some(stderr) = self.stderr.take() {
             command.stderr(stderr);
+        }
+
+        for (key, value) in &self.env {
+            command.env(key, value);
         }
 
         command


### PR DESCRIPTION
This allows passing in environment variables even when the run target is emulated, like this:

```sh
kick for --first-os --env RUSTFLAGS=-Dwarnings cargo +nightly check
```