### PR TITLE
Evaluate step conditions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.160", features = ["derive", "rc"] }
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
+syntree = "0.14.5"
 tar = "0.4.40"
 tempfile = "3.5.0"
 thiserror = "1.0.40"

--- a/src/process.rs
+++ b/src/process.rs
@@ -206,10 +206,6 @@ impl fmt::Display for Display<'_> {
             f.write_str(arg.to_string_lossy().as_ref())?;
         }
 
-        if let Some(dir) = &self.inner.current_dir {
-            write!(f, " (in {})", dir.display())?;
-        }
-
         Ok(())
     }
 }

--- a/src/workflows/eval.rs
+++ b/src/workflows/eval.rs
@@ -1,0 +1,181 @@
+use super::{Matrix, Syntax};
+
+use syntree::{index, pointer, Node, Span, Tree};
+use thiserror::Error;
+
+use Syntax::{And, DoubleString, Eq, Group, Neq, Operation, Or, SingleString, Variable};
+
+#[derive(Debug, Error)]
+#[error("{kind}")]
+#[non_exhaustive]
+pub(crate) struct EvalError<I> {
+    pub(crate) span: Span<I>,
+    pub(crate) kind: EvalErrorKind,
+}
+
+impl<I> EvalError<I> {
+    const fn new(span: Span<I>, kind: EvalErrorKind) -> Self {
+        Self { span, kind }
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum EvalErrorKind {
+    #[error("expected {0:?} but was {1:?}")]
+    Expected(Syntax, Syntax),
+
+    #[error("expected {0:?}")]
+    Missing(Syntax),
+
+    #[error("bad variable")]
+    BadVariable,
+
+    #[error("bad string")]
+    BadString,
+
+    #[error("{0:?} is not a valid operator")]
+    UnexpectedOperator(Syntax),
+
+    #[error("expected an operator")]
+    ExpectedOperator,
+
+    #[error("numerical overflow")]
+    Overflow,
+
+    #[error("numerical underflow")]
+    Underflow,
+
+    #[error("divide by zero")]
+    DivideByZero,
+}
+
+use EvalErrorKind::{
+    BadString, BadVariable, DivideByZero, Expected, ExpectedOperator, Missing, Overflow, Underflow,
+    UnexpectedOperator,
+};
+
+/// The outcome of evaluating an expression.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Expr<'m> {
+    Value(&'m str),
+    Bool(bool),
+}
+
+fn eval_node<'a, I, W>(
+    mut node: Node<'_, Syntax, I, W>,
+    source: &'a str,
+    matrix: &'a Matrix,
+) -> Result<Expr<'a>, EvalError<I>>
+where
+    I: index::Index,
+    W: pointer::Width,
+{
+    loop {
+        return match *node.value() {
+            Group => {
+                node = node
+                    .first()
+                    .ok_or(EvalError::new(*node.span(), Missing(Variable)))?;
+                continue;
+            }
+            Variable => {
+                let variable = &source[node.range()];
+
+                let Some(value) = matrix.get(variable) else {
+                    return Err(EvalError::new(*node.span(), BadVariable));
+                };
+
+                Ok(Expr::Value(value))
+            }
+            SingleString | DoubleString => {
+                let value = &source[node.range()];
+
+                let Some(value) = value.get(1..value.len().saturating_sub(1)) else {
+                    return Err(EvalError::new(*node.span(), BadString));
+                };
+
+                Ok(Expr::Value(value))
+            }
+            Operation => {
+                let mut it = node.children().skip_tokens();
+
+                let first = it
+                    .next()
+                    .ok_or(EvalError::new(*node.span(), Missing(Variable)))?;
+
+                let mut base = eval_node(first, source, matrix)?;
+
+                while let Some(op) = it.next() {
+                    let op = op
+                        .first()
+                        .ok_or(EvalError::new(*node.span(), ExpectedOperator))?;
+
+                    let (calculate, error): (fn(Expr<'_>, Expr<'_>) -> Option<Expr<'static>>, _) =
+                        match *op.value() {
+                            Eq => (op_eq, Overflow),
+                            Neq => (op_neq, Underflow),
+                            And => (op_and, Overflow),
+                            Or => (op_or, DivideByZero),
+                            what => {
+                                return Err(EvalError::new(*node.span(), UnexpectedOperator(what)))
+                            }
+                        };
+
+                    let first = it
+                        .next()
+                        .ok_or(EvalError::new(*node.span(), Missing(Variable)))?;
+
+                    let b = eval_node(first, source, matrix)?;
+
+                    base = match calculate(base, b) {
+                        Some(n) => n,
+                        None => return Err(EvalError::new(op.span().join(node.span()), error)),
+                    }
+                }
+
+                Ok(base)
+            }
+            what => Err(EvalError::new(*node.span(), Expected(Variable, what))),
+        };
+    }
+}
+
+fn op_eq(a: Expr<'_>, b: Expr<'_>) -> Option<Expr<'static>> {
+    Some(Expr::Bool(a == b))
+}
+
+fn op_neq(a: Expr<'_>, b: Expr<'_>) -> Option<Expr<'static>> {
+    Some(Expr::Bool(a != b))
+}
+
+fn op_and(a: Expr<'_>, b: Expr<'_>) -> Option<Expr<'static>> {
+    match (a, b) {
+        (Expr::Bool(a), Expr::Bool(b)) => Some(Expr::Bool(a & b)),
+        _ => None,
+    }
+}
+
+fn op_or(a: Expr<'_>, b: Expr<'_>) -> Option<Expr<'static>> {
+    match (a, b) {
+        (Expr::Bool(a), Expr::Bool(b)) => Some(Expr::Bool(a | b)),
+        _ => None,
+    }
+}
+
+/// Eval a tree emitting all available expressions parsed from it.
+pub(crate) fn eval<'a, I, W>(
+    tree: &'a Tree<Syntax, I, W>,
+    source: &'a str,
+    matrix: &'a Matrix,
+) -> impl Iterator<Item = Result<Expr<'a>, EvalError<I>>> + 'a
+where
+    I: index::Index,
+    W: pointer::Width,
+{
+    let mut it = tree.children().skip_tokens();
+
+    std::iter::from_fn(move || {
+        let node = it.next()?;
+        Some(eval_node(node, source, matrix))
+    })
+}

--- a/src/workflows/grammar.rs
+++ b/src/workflows/grammar.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+
+use super::parsing::Parser;
+use super::Syntax;
+
+use self::Syntax::*;
+
+fn op(syntax: Syntax) -> Option<(u8, u8)> {
+    let prio = match syntax {
+        And | Or => (1, 2),
+        Eq | Neq => (3, 4),
+        _ => return None,
+    };
+
+    Some(prio)
+}
+
+fn expr(p: &mut Parser<'_>, min: u8) -> Result<(), syntree::Error> {
+    // Eat all available whitespace before getting a checkpoint.
+    let tok = p.peek()?;
+
+    let c = p.tree.checkpoint()?;
+
+    match tok.syntax {
+        OpenParen => {
+            p.token()?;
+
+            let c = p.tree.checkpoint()?;
+            expr(p, 0)?;
+            p.tree.close_at(&c, Group)?;
+
+            if !p.eat(CloseParen)? {
+                p.bump(Error)?;
+                return Ok(());
+            }
+        }
+        Variable => {
+            p.bump(Variable)?;
+        }
+        SingleString => {
+            p.bump(SingleString)?;
+        }
+        DoubleString => {
+            p.bump(DoubleString)?;
+        }
+        _ => {
+            p.bump(Error)?;
+            return Ok(());
+        }
+    }
+
+    let mut operation = false;
+
+    loop {
+        let tok = p.peek()?;
+
+        let min = match op(tok.syntax) {
+            Some((left, right)) if left >= min => right,
+            _ => break,
+        };
+
+        p.bump(Operator)?;
+        expr(p, min)?;
+        operation = true;
+    }
+
+    if operation {
+        p.tree.close_at(&c, Operation)?;
+    }
+
+    Ok(())
+}
+
+/// Parse the root.
+pub(crate) fn root(p: &mut Parser<'_>) -> Result<()> {
+    loop {
+        expr(p, 0)?;
+
+        if p.is_eof()? {
+            break;
+        }
+
+        // Simple error recovery where we consume until we find an operator
+        // which will be consumed as an expression next.
+        let c = p.tree.checkpoint()?;
+        p.advance_until(&[Variable])?;
+        p.tree.close_at(&c, Error)?;
+    }
+
+    Ok(())
+}

--- a/src/workflows/lexer.rs
+++ b/src/workflows/lexer.rs
@@ -1,0 +1,155 @@
+use super::Syntax;
+
+use Syntax::{
+    And, CloseParen, DoubleString, Eq, Error, Neq, OpenParen, Or, SingleString, Variable,
+    Whitespace,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Token {
+    pub(crate) len: usize,
+    pub(crate) syntax: Syntax,
+}
+
+pub(crate) struct Lexer<'a> {
+    source: &'a str,
+    cursor: usize,
+}
+
+impl<'a> Lexer<'a> {
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self { source, cursor: 0 }
+    }
+
+    /// Peek the next character of input.
+    fn peek(&self) -> char {
+        let s = self.source.get(self.cursor..).unwrap_or_default();
+        s.chars().next().unwrap_or('\0')
+    }
+
+    /// Peek the next character of input.
+    fn peek2(&self) -> (char, char) {
+        let s = self.source.get(self.cursor..).unwrap_or_default();
+        let mut it = s.chars();
+        let a = it.next().unwrap_or('\0');
+        let b = it.next().unwrap_or('\0');
+        (a, b)
+    }
+
+    /// Step over the next character.
+    fn step(&mut self) {
+        let c = self.peek();
+
+        if self.peek() != '\0' {
+            self.cursor += c.len_utf8();
+        }
+    }
+
+    /// Step over the two next characters.
+    fn step2(&mut self) {
+        self.step();
+        self.step();
+    }
+
+    fn string(&mut self, delim: char) -> bool {
+        self.step();
+
+        loop {
+            match self.peek() {
+                '\0' => return false,
+                '\\' => {
+                    self.step();
+                    self.step();
+                }
+                c if c == delim => {
+                    self.step();
+                    break;
+                }
+                _ => self.step(),
+            }
+        }
+
+        true
+    }
+
+    /// Consume input until we hit non-numerics.
+    fn consume_while(&mut self, cond: fn(char) -> bool) {
+        loop {
+            let c = self.peek();
+
+            if !cond(c) {
+                break;
+            }
+
+            self.cursor += c.len_utf8();
+        }
+    }
+
+    /// Get the next token.
+    pub(crate) fn next(&mut self) -> Token {
+        let (a, b) = self.peek2();
+        let start = self.cursor;
+
+        let syntax = match (a, b) {
+            ('\0', _) => {
+                return Token {
+                    len: 0,
+                    syntax: Syntax::Eof,
+                }
+            }
+            (c, _) if c.is_whitespace() => {
+                self.consume_while(char::is_whitespace);
+                Whitespace
+            }
+            ('&', '&') => {
+                self.step2();
+                And
+            }
+            ('|', '|') => {
+                self.step2();
+                Or
+            }
+            ('=', '=') => {
+                self.step2();
+                Eq
+            }
+            ('!', '=') => {
+                self.step2();
+                Neq
+            }
+            ('(', _) => {
+                self.step();
+                OpenParen
+            }
+            (')', _) => {
+                self.step();
+                CloseParen
+            }
+            ('a'..='z', _) => {
+                self.consume_while(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '.'));
+                Variable
+            }
+            ('\'', _) => {
+                if self.string('\'') {
+                    SingleString
+                } else {
+                    Error
+                }
+            }
+            ('\"', _) => {
+                if self.string('"') {
+                    DoubleString
+                } else {
+                    Error
+                }
+            }
+            _ => {
+                self.consume_while(|c| !c.is_whitespace());
+                Error
+            }
+        };
+
+        let len = self.cursor.saturating_sub(start);
+        Token { len, syntax }
+    }
+}

--- a/src/workflows/parsing.rs
+++ b/src/workflows/parsing.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use syntree::{Builder, Error};
+use Syntax::{Eof, Whitespace};
+
+use super::lexer::{Lexer, Token};
+use super::Syntax;
+
+/// Parser and lexer baked into one.
+pub(crate) struct Parser<'a> {
+    lexer: Lexer<'a>,
+    pub(crate) tree: Builder<Syntax, u32, usize>,
+    // One token of lookahead.
+    buf: Option<Token>,
+}
+
+impl<'a> Parser<'a> {
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self {
+            lexer: Lexer::new(source),
+            tree: Builder::new(),
+            buf: None,
+        }
+    }
+
+    /// Peek the next token.
+    pub fn peek(&mut self) -> Result<Token, Error> {
+        // Fill up buffer.
+        self.fill()?;
+
+        if let Some(tok) = self.buf {
+            return Ok(tok);
+        }
+
+        Ok(Token {
+            len: 0,
+            syntax: Eof,
+        })
+    }
+
+    /// Test if the parser is currently at EOF.
+    pub(crate) fn is_eof(&mut self) -> Result<bool, Error> {
+        Ok(self.peek()?.syntax == Eof)
+    }
+
+    /// Try to eat the given sequence of syntax as the given node `what`.
+    pub(crate) fn eat(&mut self, what: Syntax) -> Result<bool, Error> {
+        if self.peek()?.syntax != what {
+            return Ok(false);
+        }
+
+        let tok = self.step()?;
+        self.tree.token(tok.syntax, tok.len)?;
+        Ok(true)
+    }
+
+    /// Consume a token.
+    pub(crate) fn token(&mut self) -> Result<(), Error> {
+        let tok = self.step()?;
+        self.tree.token(tok.syntax, tok.len)?;
+        Ok(())
+    }
+
+    /// Bump the current input as the given syntax.
+    pub(crate) fn bump(&mut self, what: Syntax) -> Result<(), Error> {
+        let tok = self.step()?;
+        self.tree.open(what)?;
+        self.tree.token(tok.syntax, tok.len)?;
+        self.tree.close()?;
+        Ok(())
+    }
+
+    /// Advance until one of `any` matches.
+    pub(crate) fn advance_until(&mut self, any: &[Syntax]) -> Result<(), Error> {
+        // Consume until we see another Number (or EOF) for some primitive
+        // error recovery.
+        loop {
+            let t = self.peek()?;
+
+            if t.syntax == Eof || any.iter().any(|s| *s == t.syntax) {
+                break;
+            }
+
+            self.tree.token(t.syntax, t.len)?;
+            self.step()?;
+        }
+
+        Ok(())
+    }
+
+    /// Consume the head token.
+    pub(crate) fn step(&mut self) -> Result<Token, Error> {
+        let tok = self.peek()?;
+        self.buf.take();
+        Ok(tok)
+    }
+
+    fn fill(&mut self) -> Result<(), Error> {
+        while self.buf.is_none() {
+            let tok = self.lexer.next();
+
+            if tok.syntax == Eof {
+                break;
+            };
+
+            // Consume whitespace transparently.
+            if matches!(tok.syntax, Whitespace) {
+                self.tree.token(tok.syntax, tok.len)?;
+                continue;
+            }
+
+            self.buf = Some(tok);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds support for evaluating step conditions, such as:

```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    needs: features
    strategy:
      fail-fast: false
      matrix:
        rust: ['1.76', stable]
    steps:
    - uses: actions/checkout@v4
    - uses: dtolnay/rust-toolchain@master
      with:
        toolchain: ${{matrix.rust}}
    - run: cargo build -p musli --features test
      if: matrix.rust != 'stable'
    - run: cargo build --all-targets --features test
      if: matrix.rust == 'stable'
    - run: cargo test --all-targets --features test
      if: matrix.rust == 'stable'
    - run: cargo test --doc --features test
      if: matrix.rust == 'stable'
```