### PR TITLE
Use redaction utilities

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use anyhow::Result;
@@ -81,9 +82,9 @@ impl ActionsCheck for ActionsRsToolchainActionsCheck {
         };
 
         let toolchain = if let Some(toolchain) = step.with.get("toolchain") {
-            toolchain.as_str()
+            toolchain.to_redacted()
         } else {
-            "stable"
+            Cow::Borrowed("stable")
         };
 
         let toolchain = if !toolchain.starts_with("${{") {
@@ -100,7 +101,7 @@ impl ActionsCheck for ActionsRsToolchainActionsCheck {
                 )]),
             );
 
-            "master"
+            Cow::Borrowed("master")
         };
 
         edits.set(

--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -10,7 +10,7 @@ use super::system::{Git, System};
 use crate::cargo::{self, Package, RustVersion};
 use crate::changes::{Change, Warning};
 use crate::config::{Config, Os};
-use crate::env::Env;
+use crate::env::{Env, SecretString};
 use crate::model::{RenderRustVersions, Repo, RepoParams, RepoRef, State};
 use crate::process::Command;
 use crate::repo_sets::RepoSets;
@@ -78,6 +78,19 @@ pub(crate) struct Ctxt<'a> {
 }
 
 impl<'a> Ctxt<'a> {
+    /// Get known github authentication.
+    pub(crate) fn github_auth(&self) -> Option<SecretString> {
+        if let Some(credentials) = &self.git_credentials {
+            return Some(credentials.get());
+        }
+
+        if let Some(token) = &self.env.github_token {
+            return Some(token.clone());
+        }
+
+        None
+    }
+
     /// Grab an octokit client optionally configured with a token.
     pub(crate) fn octokit(&self) -> Result<octokit::Client> {
         let auth = match (&self.git_credentials, &self.env.github_token) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,6 +344,7 @@ mod musli;
 mod octokit;
 mod packaging;
 mod process;
+mod redact;
 mod release;
 mod repo_sets;
 mod shell;

--- a/src/redact/chunks.rs
+++ b/src/redact/chunks.rs
@@ -1,0 +1,90 @@
+use core::mem::take;
+
+use super::{START, TAG_END, TAG_START};
+
+/// An iterator over the chunks of a redacted string.
+///
+/// See [`Redact::chunks`][super::Redact::chunks].
+pub(crate) struct Chunks<'a> {
+    string: &'a str,
+}
+
+impl<'a> Chunks<'a> {
+    pub(crate) fn new(string: &'a str) -> Self {
+        Self { string }
+    }
+}
+
+impl<'a> Iterator for Chunks<'a> {
+    type Item = Chunk<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.string.is_empty() {
+            return None;
+        }
+
+        let (public, redacted) = if let Some(at) = self.string.find(TAG_START) {
+            let (public, rest) = self.string.split_at(at);
+            let rest = &rest[TAG_START.len()..];
+
+            if let Some(at) = rest.find(TAG_END) {
+                let (redacted, string) = rest.split_at(at);
+                self.string = &string[TAG_END.len()..];
+                (public, redacted)
+            } else {
+                self.string = "";
+                (public, rest)
+            }
+        } else {
+            (take(&mut self.string), "")
+        };
+
+        Some(Chunk { public, redacted })
+    }
+}
+
+/// A chunk of a redacted string.
+///
+/// See [`Redact::chunks`][super::Redact::chunks].
+pub(crate) struct Chunk<'a> {
+    public: &'a str,
+    redacted: &'a str,
+}
+
+impl<'a> Chunk<'a> {
+    /// Get the public part of the chunk.
+    pub(crate) fn public(&self) -> &str {
+        self.public
+    }
+
+    /// Get the redacted part of the chunk.
+    pub(crate) fn redacted(&self) -> Redacted<'_> {
+        // SAFETY: We know that the redacted part is ASCII markup.
+        Redacted {
+            string: self.redacted,
+        }
+    }
+}
+
+/// A redacted string.
+pub(crate) struct Redacted<'a> {
+    string: &'a str,
+}
+
+impl Iterator for Redacted<'_> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut it = self.string.chars();
+
+        let Some(c) = it.next() else {
+            self.string = "";
+            return None;
+        };
+
+        self.string = it.as_str();
+
+        // SAFETY: We know that `c` is an ASCII character in the tag range.
+        Some(unsafe { char::from_u32_unchecked((c as u32) - START) })
+    }
+}

--- a/src/redact/mod.rs
+++ b/src/redact/mod.rs
@@ -1,0 +1,353 @@
+mod chunks;
+pub(crate) use self::chunks::Chunks;
+
+#[cfg(test)]
+mod tests;
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::ops::Deref;
+use std::borrow::{Borrow, Cow};
+use std::hash::{Hash, Hasher};
+
+// The start of the Unicode tag sequence.
+//
+// While the sequence is deprecated, it's frequently treated as markup and
+// ignored when printed.
+const START: u32 = 0xE0000;
+const TAG_START: &str = "\u{E0001}";
+const TAG_END: &str = "\u{E007F}";
+
+/// A borrowed string which might contain redacted sequences.
+///
+/// Trying to format the string will result in those redacted sequences being
+/// marked as `***`.
+#[repr(transparent)]
+pub(crate) struct Redact(str);
+
+impl Redact {
+    /// Construct a new redacted string wrapping the given string.
+    pub(crate) fn new<S>(s: &S) -> &Self
+    where
+        S: ?Sized + AsRef<str>,
+    {
+        // This is safe because `Redacted` is a transparent wrapper around `str`.
+        unsafe { &*(s.as_ref() as *const str as *const Redact) }
+    }
+
+    /// Check if the redacted string is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Iterate over chunks of the redacted string.
+    pub(crate) fn chunks(&self) -> Chunks<'_> {
+        Chunks::new(&self.0)
+    }
+
+    /// Split the redacted string oncoe over the given string.
+    pub(crate) fn split_once(&self, c: char) -> Option<(&Redact, &Redact)> {
+        let (a, b) = self.0.split_once(c)?;
+        Some((Redact::new(a), Redact::new(b)))
+    }
+
+    /// Get the raw underlying string.
+    ///
+    /// This should not be used to display the string, as it will contain the
+    /// redacted string even though it is encoded.
+    pub(crate) fn as_raw(&self) -> &str {
+        &self.0
+    }
+
+    /// Coerce into the interior string, removing the redaction markup.
+    pub(crate) fn to_redacted(&self) -> Cow<'_, str> {
+        let Some(until) = self.0.find(TAG_START) else {
+            return Cow::Borrowed(&self.0);
+        };
+
+        let mut out = String::with_capacity(self.0.len());
+        let (head, tail) = self.0.split_at(until);
+        out.push_str(head);
+
+        for chunk in Redact::new(tail).chunks() {
+            out.push_str(chunk.public());
+            out.extend(chunk.redacted());
+        }
+
+        Cow::Owned(out)
+    }
+}
+
+impl AsRef<Redact> for Redact {
+    #[inline]
+    fn as_ref(&self) -> &Redact {
+        self
+    }
+}
+
+impl fmt::Display for Redact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for chunk in self.chunks() {
+            f.write_str(chunk.public())?;
+
+            if chunk.redacted().next().is_some() {
+                f.write_str("***")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Redact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "\"")?;
+
+        for chunk in self.chunks() {
+            f.write_str(chunk.public())?;
+
+            if chunk.redacted().next().is_some() {
+                f.write_str("***")?;
+            }
+        }
+
+        write!(f, "\"")?;
+        Ok(())
+    }
+}
+
+/// A string which might contain redacted components.
+///
+/// Redacted components are marked with special tags, any formatting of this
+/// string will cause them to show up as `***`.
+///
+/// To access the raw underlying string, you should use [`to_redacted`].
+/// Alternatively you can iterate over the chunks of the string using
+/// [`chunks`].
+///
+/// [`to_redacted`]: Redact::to_redacted
+/// [`chunks`]: Redact::chunks
+#[derive(Clone)]
+pub(crate) struct OwnedRedact(String);
+
+impl OwnedRedact {
+    /// Construct a new empty redacted string.
+    pub(crate) const fn new() -> Self {
+        OwnedRedact(String::new())
+    }
+    /// Construct a new empty redacted string with the given `capacity`.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        OwnedRedact(String::with_capacity(capacity))
+    }
+
+    /// Get a reference to the [`Redact`] value corresponding to this instance.
+    pub(crate) fn as_redact(&self) -> &Redact {
+        self
+    }
+
+    /// Construct a new redacted string. This can only contain ascii characters.
+    pub(crate) fn redacted<S>(s: S) -> Option<Self>
+    where
+        S: AsRef<str>,
+    {
+        let s = s.as_ref();
+        let mut out = Self::with_capacity(s.len() + 2);
+
+        if !out.push_redacted(s.as_ref()) {
+            return None;
+        }
+
+        Some(out)
+    }
+
+    /// Push another raw non-redacted char.
+    pub(crate) fn push(&mut self, c: char) {
+        self.0.push(c);
+    }
+
+    /// Push another raw non-redacted string.
+    pub(crate) fn push_str(&mut self, s: &str) {
+        self.0.push_str(s);
+    }
+
+    /// Push a redacted string.
+    pub(crate) fn push_redacted(&mut self, s: &str) -> bool {
+        self.0.push_str(TAG_START);
+
+        for c in s.chars() {
+            if !c.is_ascii() || c.is_ascii_control() {
+                return false;
+            }
+
+            // SAFETY: We know that `c` is an ASCII character.
+            self.0
+                .push(unsafe { char::from_u32_unchecked(c as u32 + START) });
+        }
+
+        self.0.push_str(TAG_END);
+        true
+    }
+}
+
+impl From<String> for OwnedRedact {
+    #[inline]
+    fn from(value: String) -> Self {
+        OwnedRedact(value)
+    }
+}
+
+impl From<&String> for OwnedRedact {
+    #[inline]
+    fn from(value: &String) -> Self {
+        OwnedRedact(value.clone())
+    }
+}
+
+impl From<&str> for OwnedRedact {
+    #[inline]
+    fn from(value: &str) -> Self {
+        OwnedRedact(value.into())
+    }
+}
+
+impl From<&Redact> for OwnedRedact {
+    #[inline]
+    fn from(value: &Redact) -> Self {
+        value.to_owned()
+    }
+}
+
+impl Deref for OwnedRedact {
+    type Target = Redact;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        Redact::new(&self.0)
+    }
+}
+
+impl ToOwned for Redact {
+    type Owned = OwnedRedact;
+
+    #[inline]
+    fn to_owned(&self) -> Self::Owned {
+        OwnedRedact(self.0.to_owned())
+    }
+}
+
+impl Borrow<Redact> for OwnedRedact {
+    #[inline]
+    fn borrow(&self) -> &Redact {
+        self
+    }
+}
+
+impl AsRef<Redact> for OwnedRedact {
+    #[inline]
+    fn as_ref(&self) -> &Redact {
+        self
+    }
+}
+
+impl fmt::Display for OwnedRedact {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl fmt::Debug for OwnedRedact {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl fmt::Write for OwnedRedact {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+}
+
+impl AsRef<Redact> for str {
+    #[inline]
+    fn as_ref(&self) -> &Redact {
+        Redact::new(self)
+    }
+}
+
+impl AsRef<Redact> for String {
+    #[inline]
+    fn as_ref(&self) -> &Redact {
+        Redact::new(self.as_str())
+    }
+}
+
+macro_rules! cmp {
+    ($ty:ty) => {
+        impl Hash for $ty {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: Hasher,
+            {
+                self.0.hash(state);
+            }
+        }
+
+        impl PartialEq for $ty {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl PartialEq<str> for $ty {
+            #[inline]
+            fn eq(&self, other: &str) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<$ty> for str {
+            #[inline]
+            fn eq(&self, other: &$ty) -> bool {
+                *self == other.0
+            }
+        }
+
+        impl PartialEq<&str> for $ty {
+            #[inline]
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == **other
+            }
+        }
+
+        impl PartialEq<$ty> for &str {
+            #[inline]
+            fn eq(&self, other: &$ty) -> bool {
+                **self == other.0
+            }
+        }
+
+        impl Eq for $ty {}
+
+        impl PartialOrd for $ty {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.0.cmp(&other.0))
+            }
+        }
+
+        impl Ord for $ty {
+            #[inline]
+            fn cmp(&self, other: &Self) -> Ordering {
+                self.0.cmp(&other.0)
+            }
+        }
+    };
+}
+
+cmp!(Redact);
+cmp!(OwnedRedact);

--- a/src/redact/tests.rs
+++ b/src/redact/tests.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+#[test]
+fn test_redact() {
+    let mut owned = OwnedRedact::new();
+    owned.push_str("this is a password: ");
+    owned.push_redacted("hunter2");
+    owned.push_str("... now the secret is out!");
+
+    assert_eq!(
+        format!("See {owned}"),
+        "See this is a password: ***... now the secret is out!"
+    );
+
+    assert_eq!(
+        owned.to_redacted(),
+        "this is a password: hunter2... now the secret is out!"
+    );
+}

--- a/src/system/powershell.rs
+++ b/src/system/powershell.rs
@@ -6,6 +6,7 @@ use std::process::{ExitStatus, Stdio};
 use anyhow::{Context, Result};
 
 use crate::process::Command;
+use crate::redact::Redact;
 
 #[derive(Debug)]
 pub(crate) struct PowerShell {
@@ -19,12 +20,13 @@ impl PowerShell {
     }
 
     /// Run a powershell command.
-    pub(crate) fn command<D>(&self, dir: D, command: &str) -> Command
+    pub(crate) fn command<D>(&self, dir: D, command: &Redact) -> Command
     where
         D: AsRef<Path>,
     {
         let mut c = Command::new(&self.command);
-        c.args(["-Command", command]);
+        c.arg("-Command");
+        c.arg_redact(command);
         c.current_dir(dir);
         c
     }

--- a/src/workflows/eval.rs
+++ b/src/workflows/eval.rs
@@ -3,6 +3,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::str::FromStr;
 
+use crate::redact::{OwnedRedact, Redact};
+
 use super::{Eval, Syntax};
 
 use syntree::{pointer, Node, Span, Tree};
@@ -85,7 +87,7 @@ pub(crate) enum Expr<'m> {
     /// An array of values.
     Array(Box<[Expr<'m>]>),
     /// A string expression.
-    String(Cow<'m, str>),
+    String(Cow<'m, Redact>),
     /// A floating-point expression.
     Float(f64),
     /// A boolean expression.
@@ -98,7 +100,7 @@ pub(crate) enum Expr<'m> {
 impl<'m> From<&'m str> for Expr<'m> {
     #[inline]
     fn from(s: &'m str) -> Self {
-        Self::String(Cow::Borrowed(s))
+        Self::String(Cow::Borrowed(Redact::new(s)))
     }
 }
 
@@ -153,7 +155,7 @@ impl Expr<'_> {
     }
 
     /// Get the expression as a string.
-    pub(crate) fn as_str(&self) -> Option<&str> {
+    pub(crate) fn as_str(&self) -> Option<&Redact> {
         match *self {
             Self::String(ref string) => Some(string),
             _ => None,
@@ -243,6 +245,11 @@ where
 
                 let Some(value) = unescape(value) else {
                     return Err(EvalError::new(*node.span(), BadString(value.into())));
+                };
+
+                let value = match value {
+                    Cow::Borrowed(s) => Cow::Borrowed(Redact::new(s)),
+                    Cow::Owned(s) => Cow::Owned(OwnedRedact::from(s)),
                 };
 
                 Ok(Expr::String(value))

--- a/src/workflows/lexer.rs
+++ b/src/workflows/lexer.rs
@@ -186,12 +186,12 @@ impl<'a> Lexer<'a> {
                 self.number();
                 Number
             }
-            ('a'..='z', _, _) => {
+            ('a'..='z' | 'A'..='Z', _, _) => {
                 self.consume_while(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-'));
 
                 match &self.source[start..self.cursor] {
                     "true" | "false" => Bool,
-                    "nan" => Number,
+                    "nan" | "NaN" => Number,
                     "null" => Null,
                     _ => Ident,
                 }

--- a/src/workflows/tests.rs
+++ b/src/workflows/tests.rs
@@ -26,7 +26,7 @@ fn or_test() {
 
     assert_eq!(
         eval.expr("matrix.foo || matrix.bar"),
-        Ok(Expr::String(Cow::Borrowed("right")))
+        Ok(Expr::String(Cow::Borrowed(Redact::new("right"))))
     );
 }
 
@@ -40,7 +40,7 @@ fn and_test() {
 
     assert_eq!(
         eval.expr("matrix.foo && matrix.bar"),
-        Ok(Expr::String(Cow::Borrowed("right")))
+        Ok(Expr::String(Cow::Borrowed(Redact::new("right"))))
     );
 
     assert_eq!(eval.expr("matrix.baz && matrix.bar"), Ok(Expr::Null));
@@ -56,7 +56,7 @@ fn group() {
 
     assert_eq!(
         eval.expr("${{ matrix.foo }} && matrix.bar"),
-        Ok(Expr::String(Cow::Borrowed("right")))
+        Ok(Expr::String(Cow::Borrowed(Redact::new("right"))))
     );
 
     assert_eq!(eval.expr("matrix.baz && matrix.bar"), Ok(Expr::Null));
@@ -89,7 +89,9 @@ fn lazy_expansion() {
         'value_for_other_branches'
         "#
         ),
-        Ok(Expr::String(Cow::Borrowed("value_for_main_branch")))
+        Ok(Expr::String(Cow::Borrowed(Redact::new(
+            "value_for_main_branch"
+        ))))
     );
 
     assert_eq!(
@@ -99,7 +101,9 @@ fn lazy_expansion() {
         'value_for_other_branches'
         "#
         ),
-        Ok(Expr::String(Cow::Borrowed("value_for_other_branches")))
+        Ok(Expr::String(Cow::Borrowed(Redact::new(
+            "value_for_other_branches"
+        ))))
     );
 }
 


### PR DESCRIPTION
Every value that might contain a secret is wrapped in a new set of redaction types, which allows you to mark spans of texts which should be considered sensitive. If these are printed or used without using the proper APIs, these secrets are represented as three stars `***`. This will help to avoid secrets from being printed in CLIs, like credentials loaded from git even if they're used when running commands.

As an example, this is what the output from running a job in this repo which uses `secrets.GITHUB_SECRETS`:

```shell
$ kick run --job publish --same-os --dry-run
# In .
# Step 1 / 1: powershell.exe -Command "kick github-release --upload \"dist/*\" --github-action"
powershell -Command {
  $Env:GITHUB_TOKEN="***";
  $Env:KICK_VERSION=" || nightly";
  $Env:RUST_LOG="kick=trace";
  powershell.exe -Command "kick github-release --upload \"dist/*\" --github-action"
}
```